### PR TITLE
Print out what changes --replace would make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ jobs:
           - v1-dependencies-
 
       - run: wget https://github.com/google/google-java-format/releases/download/google-java-format-1.5/google-java-format-1.5-all-deps.jar
-      - run: java -jar google-java-format*.jar -n --set-exit-if-changed $(find . -name "*.java")
+      - run: java -jar google-java-format-1.5-all-deps.jar --replace $(find . -name "*.java")
+      - run: "! (git diff | grep .)"
       - run: mvn dependency:go-offline
 
       - save_cache:


### PR DESCRIPTION
Currently, the linter can be a little frustrating to use: it just prints out what files it thinks needs to reformat. This change performs the lint update on the CircleCI worker's local Git repository, then checks to see what changed. As a result, we get a nice diff view showing what it thinks should be updated.

Passing run: https://circleci.com/gh/codeu-2018-team12/codeu-2018-team12/48
Failing run (I messed with the indentation): https://circleci.com/gh/codeu-2018-team12/codeu-2018-team12/46

Hopefully that will be a bit easier to use.