### PR TITLE
Set up a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code ownership file.
+#
+# Details: https://help.github.com/articles/about-codeowners/
+
+# Add everybody on the team to every pull request.
+*	@Mariamcm92 @mariezimmy @kkane098 @alisonrosenman


### PR DESCRIPTION
The CODEOWNERS file is a convention for very large codebases that have several teams collaborating together. In this case, we only have a single team, but we can still use this configuration to automatically add everybody to new code reviews.

https://help.github.com/articles/about-codeowners/