### PR TITLE
Password confirmation and empty conversation name

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -100,6 +100,12 @@ public class ConversationServlet extends HttpServlet {
     }
 
     String conversationTitle = request.getParameter("conversationTitle");
+    if (conversationTitle.isEmpty()) {
+      request.setAttribute("error", "Please specify a name for this chat.");
+      request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
+      return;
+    }
+
     if (!conversationTitle.matches("[\\w*]*")) {
       request.setAttribute("error", "Please enter only letters and numbers.");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);

--- a/src/main/webapp/WEB-INF/view/register.jsp
+++ b/src/main/webapp/WEB-INF/view/register.jsp
@@ -39,7 +39,7 @@
       <input type="password" name="password" id="password">
       <br/>
       <label for="confirmPassword">Confirm Password: </label>
-      <input type="text" name="confirmPassword" id="confirmPassword">
+      <input type="password" name="confirmPassword" id="confirmPassword">
       <br/>
       <br/><br/>
       <button type="submit">Submit</button>

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -101,6 +101,22 @@ public class ConversationServletTest {
   }
 
   @Test
+  public void testDoPost_EmptyConversationName() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    conversationServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockConversationStore, Mockito.never())
+        .addConversation(Mockito.any(Conversation.class));
+    Mockito.verify(mockRequest).setAttribute("error", "Please specify a name for this chat.");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+
+  @Test
   public void testDoPost_BadConversationName() throws IOException, ServletException {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("bad !@#$% name");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");


### PR DESCRIPTION
Fixes #45 and #46

I also realized that if you get the error message for not specifying a conversation name, the list of existing conversations disappears. I have to run to class but I'll fix that in the next pull request or just add it to this one. 