### PR TITLE
Added ability to persist activities (Maria) + Added Biography and made it editable (Alison)

### DIFF
--- a/src/main/java/codeu/controller/ActivityServlet.java
+++ b/src/main/java/codeu/controller/ActivityServlet.java
@@ -1,9 +1,7 @@
 package codeu.controller;
 
-import codeu.model.data.Message;
-import codeu.model.store.basic.ConversationStore;
-import codeu.model.store.basic.MessageStore;
-import codeu.model.store.basic.UserStore;
+import codeu.model.data.Activity;
+import codeu.model.store.basic.ActivityStore;
 import java.io.IOException;
 import java.util.List;
 import javax.servlet.ServletException;
@@ -14,46 +12,22 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet class responsible for activity feed. */
 public class ActivityServlet extends HttpServlet {
 
-  /** Store class that gives access to users. */
-  private UserStore userStore;
-
-  /** Store class that gives access to messages */
-  private MessageStore messageStore;
-
-  /** Store class that gives access to conversations */
-  private ConversationStore conversationStore;
+  /** Store class that gives access to activities. */
+  private ActivityStore activityStore;
 
   /** Set up state for handling activity-related requests */
   @Override
   public void init() throws ServletException {
     super.init();
-    setUserStore(UserStore.getInstance());
-    setMessageStore(MessageStore.getInstance());
-    setConversationStore(ConversationStore.getInstance());
+    setActivityStore(ActivityStore.getInstance());
   }
 
   /**
-   * Sets the UserStore used by this servlet. This function provides a common setup method for use
-   * by the test framework or the servlet's init() function.
-   */
-  void setUserStore(UserStore userStore) {
-    this.userStore = userStore;
-  }
-
-  /**
-   * Sets the MessageStore used by this servlet. This function provides a common setup method for
+   * Sets the ActivityStore used by this servlet. This function provides a common setup method for
    * use by the test framework or the servlet's init() function.
    */
-  void setMessageStore(MessageStore messageStore) {
-    this.messageStore = messageStore;
-  }
-
-  /**
-   * Sets the ConversationStore used by this servlet. This function provides a common setup method
-   * for use by the test framework or the servlet's init() function.
-   */
-  void setConversationStore(ConversationStore conversationStore) {
-    this.conversationStore = conversationStore;
+  void setActivityStore(ActivityStore activityStore) {
+    this.activityStore = activityStore;
   }
 
   /**
@@ -64,8 +38,8 @@ public class ActivityServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
 
-    List<Message> messages = messageStore.getAllMessages();
-    request.setAttribute("messages", messages);
+    List<Activity> activities = activityStore.getAllActivities();
+    request.setAttribute("activities", activities);
 
     request.getRequestDispatcher("/WEB-INF/view/activityFeed.jsp").forward(request, response);
   }

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -145,14 +145,14 @@ public class ChatServlet extends HttpServlet {
     }
 
     if ("joinButton".equals(button)) {
-      conversation.conversationUsers.add(user);
+      conversation.getConversationUsers.add(user);
     }
 
     if ("leaveButton".equals(button)) {
-      conversation.conversationUsers.remove(user);
+      conversation.getCnversationUsers.remove(user);
     }
 
-    if (button == null && conversation.conversationUsers.contains(user)) {
+    if (button == null && conversation.getConversationUsers.contains(user)) {
       String messageContent = request.getParameter("message");
 
       // this removes any HTML from the message content

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -85,7 +85,7 @@ public class ChatServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
-          throws IOException, ServletException {
+      throws IOException, ServletException {
     String requestUrl = request.getRequestURI();
     String conversationTitle = requestUrl.substring("/chat/".length());
 
@@ -116,7 +116,7 @@ public class ChatServlet extends HttpServlet {
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response)
-          throws IOException, ServletException {
+      throws IOException, ServletException {
 
     String button = request.getParameter("button");
 
@@ -145,29 +145,29 @@ public class ChatServlet extends HttpServlet {
     }
 
     if ("joinButton".equals(button)) {
-      conversation.getConversationUsers.add(user);
+      conversation.getConversationUsers().add(user);
     }
 
     if ("leaveButton".equals(button)) {
-      conversation.getCnversationUsers.remove(user);
+      conversation.getConversationUsers().remove(user);
     }
 
-    if (button == null && conversation.getConversationUsers.contains(user)) {
+    if (button == null && conversation.getConversationUsers().contains(user)) {
       String messageContent = request.getParameter("message");
 
       // this removes any HTML from the message content
       String cleanedMessageContent =
-              Jsoup.clean(
-                      messageContent, "", Whitelist.none(), new OutputSettings().prettyPrint(false));
+          Jsoup.clean(
+              messageContent, "", Whitelist.none(), new OutputSettings().prettyPrint(false));
       String finalMessageContent = TextFormatter.formatForDisplay(cleanedMessageContent);
 
       Message message =
-              new Message(
-                      UUID.randomUUID(),
-                      conversation.getId(),
-                      user.getId(),
-                      finalMessageContent,
-                      Instant.now());
+          new Message(
+              UUID.randomUUID(),
+              conversation.getId(),
+              user.getId(),
+              finalMessageContent,
+              Instant.now());
       messageStore.addMessage(message);
     }
     // redirect to a GET request

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -85,7 +85,7 @@ public class ChatServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
-      throws IOException, ServletException {
+          throws IOException, ServletException {
     String requestUrl = request.getRequestURI();
     String conversationTitle = requestUrl.substring("/chat/".length());
 
@@ -116,7 +116,7 @@ public class ChatServlet extends HttpServlet {
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response)
-      throws IOException, ServletException {
+          throws IOException, ServletException {
 
     String button = request.getParameter("button");
 
@@ -157,17 +157,17 @@ public class ChatServlet extends HttpServlet {
 
       // this removes any HTML from the message content
       String cleanedMessageContent =
-          Jsoup.clean(
-              messageContent, "", Whitelist.none(), new OutputSettings().prettyPrint(false));
+              Jsoup.clean(
+                      messageContent, "", Whitelist.none(), new OutputSettings().prettyPrint(false));
       String finalMessageContent = TextFormatter.formatForDisplay(cleanedMessageContent);
 
       Message message =
-          new Message(
-              UUID.randomUUID(),
-              conversation.getId(),
-              user.getId(),
-              finalMessageContent,
-              Instant.now());
+              new Message(
+                      UUID.randomUUID(),
+                      conversation.getId(),
+                      user.getId(),
+                      finalMessageContent,
+                      Instant.now());
       messageStore.addMessage(message);
     }
     // redirect to a GET request

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -101,6 +101,8 @@ public class ConversationServlet extends HttpServlet {
 
     String conversationTitle = request.getParameter("conversationTitle");
     if (conversationTitle.isEmpty()) {
+      List<Conversation> conversations = conversationStore.getAllConversations();
+      request.setAttribute("conversations", conversations);
       request.setAttribute("error", "Please specify a name for this chat.");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
       return;

--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -81,5 +81,11 @@ public class ProfileServlet extends HttpServlet {
   /** This function fires when a user submits the form on the profile page. */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response)
-      throws IOException, ServletException {}
+      throws IOException, ServletException {
+    String requestUrl = request.getRequestURI();
+    String name = requestUrl.substring("/profile/".length());
+    User user = userStore.getUser(name);
+    user.biography = request.getParameter("newBio");
+    response.sendRedirect(requestUrl);
+  }
 }

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -95,7 +95,7 @@ public class RegisterServlet extends HttpServlet {
       return;
     }
 
-    User user = new User(UUID.randomUUID(), username, passwordHash, Instant.now());
+    User user = new User(UUID.randomUUID(), username, passwordHash, null, Instant.now());
     userStore.addUser(user);
 
     String message = username + " created an account!";

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -1,6 +1,8 @@
 package codeu.controller;
 
+import codeu.model.data.Activity;
 import codeu.model.data.User;
+import codeu.model.store.basic.ActivityStore;
 import codeu.model.store.basic.UserStore;
 import java.io.IOException;
 import java.time.Instant;
@@ -17,6 +19,9 @@ public class RegisterServlet extends HttpServlet {
   /** Store class that gives access to Users. */
   private UserStore userStore;
 
+  /** Store class that gives access to Activities. */
+  private ActivityStore activityStore;
+
   /**
    * Set up state for handling registration-related requests. This method is only called when
    * running in a server, not when running in a test.
@@ -25,6 +30,7 @@ public class RegisterServlet extends HttpServlet {
   public void init() throws ServletException {
     super.init();
     setUserStore(UserStore.getInstance());
+    setActivityStore(ActivityStore.getInstance());
   }
 
   /**
@@ -33,6 +39,14 @@ public class RegisterServlet extends HttpServlet {
    */
   void setUserStore(UserStore userStore) {
     this.userStore = userStore;
+  }
+
+  /**
+   * Sets the ActivityStore used by this servlet. This function provides a common setup method for
+   * use by the test framework or the servlet's init() function.
+   */
+  void setActivityStore(ActivityStore activityStore) {
+    this.activityStore = activityStore;
   }
 
   @Override
@@ -83,6 +97,17 @@ public class RegisterServlet extends HttpServlet {
 
     User user = new User(UUID.randomUUID(), username, passwordHash, Instant.now());
     userStore.addUser(user);
+
+    String message = username + " created an account!";
+    UUID userId = user.getId();
+
+    // Empty/nil conversationId
+    UUID conversationId = new UUID(0L, 0L);
+
+    Activity activity =
+        new Activity(
+            UUID.randomUUID(), userId, conversationId, Instant.now(), "joinedApp", message);
+    activityStore.addActivity(activity);
 
     response.sendRedirect("/login");
   }

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -1,8 +1,10 @@
 package codeu.controller;
 
+import codeu.model.data.Activity;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.store.basic.ActivityStore;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
@@ -30,6 +32,9 @@ public class ServerStartupListener implements ServletContextListener {
 
       List<Message> messages = PersistentStorageAgent.getInstance().loadMessages();
       MessageStore.getInstance().setMessages(messages);
+
+      List<Activity> activities = PersistentStorageAgent.getInstance().loadActivities();
+      ActivityStore.getInstance().setActivities(activities);
 
     } catch (PersistentDataStoreException e) {
       System.err.println("Server didn't start correctly. An error occurred during Datastore load!");

--- a/src/main/java/codeu/controller/TestDataServlet.java
+++ b/src/main/java/codeu/controller/TestDataServlet.java
@@ -14,6 +14,7 @@
 
 package codeu.controller;
 
+import codeu.model.store.basic.ActivityStore;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
@@ -35,6 +36,9 @@ public class TestDataServlet extends HttpServlet {
   /** Store class that gives access to Users. */
   private UserStore userStore;
 
+  /** Store class that gives access to Activities. */
+  private ActivityStore activityStore;
+
   /** Set up state for handling the load test data request. */
   @Override
   public void init() throws ServletException {
@@ -42,6 +46,7 @@ public class TestDataServlet extends HttpServlet {
     setConversationStore(ConversationStore.getInstance());
     setMessageStore(MessageStore.getInstance());
     setUserStore(UserStore.getInstance());
+    setActivityStore(ActivityStore.getInstance());
   }
 
   /**
@@ -69,6 +74,14 @@ public class TestDataServlet extends HttpServlet {
   }
 
   /**
+   * Sets the AcitvityStore used by this servlet. This function provides a common setup method for
+   * use by the test framework or the servlet's init() function.
+   */
+  void setActivityStore(ActivityStore activityStore) {
+    this.activityStore = activityStore;
+  }
+
+  /**
    * This function fires when a user requests the /testdata URL. It simply forwards the request to
    * testdata.jsp.
    */
@@ -91,6 +104,7 @@ public class TestDataServlet extends HttpServlet {
       userStore.loadTestData();
       conversationStore.loadTestData();
       messageStore.loadTestData();
+      activityStore.loadTestData();
     }
 
     response.sendRedirect("/");

--- a/src/main/java/codeu/model/data/Activity.java
+++ b/src/main/java/codeu/model/data/Activity.java
@@ -1,0 +1,93 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.model.data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Class representing a conversation, which can be thought of as a chat room. Conversations are
+ * created by a User and contain Messages.
+ */
+public class Activity {
+  private final UUID id;
+  private final UUID user;
+  private final UUID conversationId;
+  private final Instant creation;
+  private final String activityType;
+  private final String activityMessage;
+
+  /**
+   * Constructs a new activity. Invoked when a conversation id is specified
+   *
+   * @param id the ID of this Activity
+   * @param userId the ID of the user who is attached to this activity
+   * @param creation the creation time of this activity
+   * @param activityType the type of activity represented by this message
+   * @param conversationId the ID of the conversation associated with this activity
+   */
+  public Activity(
+      UUID id,
+      UUID userId,
+      UUID conversationId,
+      Instant creation,
+      String activityType,
+      String activityMessage) {
+    this.id = id;
+    this.user = userId;
+    this.conversationId = conversationId;
+    this.creation = creation;
+    this.activityType = activityType;
+    this.activityMessage = activityMessage;
+  }
+
+  /** Returns the ID of this activity */
+  public UUID getId() {
+    return id;
+  }
+
+  /** Returns the ID of the user associated with this activity */
+  public UUID getUserId() {
+    return user;
+  }
+
+  /**
+   * Returns the ID of the conversation associated with this activity (Will return a nil/empty UUID
+   * if no conversation associated)
+   */
+  public UUID getConversationId() {
+    return conversationId;
+  }
+
+  /** Returns the creation time of this activity */
+  public Instant getCreationTime() {
+    return creation;
+  }
+
+  /**
+   * This method returns a string describing an activity type of the following five formats: 1.
+   * joinedApp (user newly created an account on the chat app), 2. joinedConvo (user joined an
+   * existing conversation), 3. leftConvo (user left a conversation), 4. createdConvo (user created
+   * a new conversation), 5. messageSent (user sent a message in a conversation)
+   */
+  public String getActivityType() {
+    return activityType;
+  }
+
+  /** Returns the message of this activity. */
+  public String getActivityMessage() {
+    return activityMessage;
+  }
+}

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -25,12 +25,12 @@ import java.util.UUID;
  * created by a User and contain Messages.
  */
 public class Conversation {
-  public final UUID id;
-  public final UUID owner;
-  public final Instant creation;
-  public final String title;
-  public UserStore userStore = UserStore.getInstance();
-  public List<User> conversationUsers = new ArrayList<>();
+  private final UUID id;
+  private final UUID owner;
+  private final Instant creation;
+  private final String title;
+  private UserStore userStore = UserStore.getInstance();
+  private List<User> conversationUsers = new ArrayList<>();
 
   /**
    * Constructs a new Conversation.

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -22,6 +22,7 @@ public class User {
   private final UUID id;
   private final String name;
   private final String hashedPassword;
+  public String biography;
   private final Instant creation;
 
   /**
@@ -32,10 +33,11 @@ public class User {
    * @param hashedPassword the hashed password of this User
    * @param creation the creation time of this User
    */
-  public User(UUID id, String name, String hashedPassword, Instant creation) {
+  public User(UUID id, String name, String hashedPassword, String biography, Instant creation) {
     this.id = id;
     this.name = name;
     this.hashedPassword = hashedPassword;
+    this.biography = biography;
     this.creation = creation;
   }
 
@@ -52,6 +54,10 @@ public class User {
   /** Returns the hashedPassword of this User. */
   public String getPassword() {
     return hashedPassword;
+  }
+
+  public String getBio() {
+    return biography;
   }
 
   /** Returns the creation time of this User. */

--- a/src/main/java/codeu/model/store/basic/ActivityStore.java
+++ b/src/main/java/codeu/model/store/basic/ActivityStore.java
@@ -1,0 +1,119 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.model.store.basic;
+
+import codeu.model.data.Activity;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Store class that uses in-memory data structures to hold values and automatically loads from and
+ * saves to PersistentStorageAgent. It's a singleton so all servlet classes can access the same
+ * instance.
+ */
+public class ActivityStore {
+
+  /** Singleton instance of ActivityStore. */
+  private static ActivityStore instance;
+
+  private Comparator<Activity> activityComparator =
+      new Comparator<Activity>() {
+        public int compare(Activity copvOne, Activity copvTwo) {
+          return copvTwo.getCreationTime().compareTo(copvOne.getCreationTime());
+        }
+      };
+
+  /**
+   * Returns the singleton instance of ActivityStore that should be shared between all servlet
+   * classes. Do not call this function from a test; use getTestInstance() instead.
+   */
+  public static ActivityStore getInstance() {
+    if (instance == null) {
+      instance = new ActivityStore(PersistentStorageAgent.getInstance());
+    }
+    return instance;
+  }
+
+  /**
+   * Instance getter function used for testing. Supply a mock for PersistentStorageAgent.
+   *
+   * @param persistentStorageAgent a mock used for testing
+   */
+  public static ActivityStore getTestInstance(PersistentStorageAgent persistentStorageAgent) {
+    return new ActivityStore(persistentStorageAgent);
+  }
+
+  /**
+   * The PersistentStorageAgent responsible for loading Activities from and saving Activities to
+   * Datastore.
+   */
+  private PersistentStorageAgent persistentStorageAgent;
+
+  /** The in-memory list of Activities. */
+  private List<Activity> activities;
+
+  /** This class is a singleton, so its constructor is private. Call getInstance() instead. */
+  private ActivityStore(PersistentStorageAgent persistentStorageAgent) {
+    this.persistentStorageAgent = persistentStorageAgent;
+    activities = new ArrayList<>();
+  }
+
+  /**
+   * Load a set of randomly-generated Activity objects.
+   *
+   * @return false if a error occurs.
+   */
+  public boolean loadTestData() {
+    boolean loaded = false;
+    try {
+      activities.addAll(DefaultDataStore.getInstance().getAllActivities());
+      loaded = true;
+    } catch (Exception e) {
+      loaded = false;
+      System.err.println("ERROR: Unable to establish initial store (conversations).");
+    }
+    return loaded;
+  }
+
+  /** Access the current set of activities known to the application. */
+  public List<Activity> getAllActivities() {
+    activities.sort(activityComparator);
+    return activities;
+  }
+
+  /** Add a new activity to the current set of activities known to the application. */
+  public void addActivity(Activity activity) {
+    activities.add(activity);
+    persistentStorageAgent.writeThrough(activity);
+  }
+
+  /** Find and return the activity with the given Id. */
+  public Activity getActivityWithId(UUID Id) {
+    for (Activity activity : activities) {
+      if (activity.getId().equals(Id)) {
+        return activity;
+      }
+    }
+    return null;
+  }
+
+  /** Sets the list of activities stored by this ActivityStore. */
+  public void setActivities(List<Activity> activities) {
+    this.activities = activities;
+  }
+}

--- a/src/main/java/codeu/model/store/basic/DefaultDataStore.java
+++ b/src/main/java/codeu/model/store/basic/DefaultDataStore.java
@@ -120,6 +120,7 @@ public class DefaultDataStore {
               UUID.randomUUID(),
               randomUsernames.get(i),
               BCrypt.hashpw("password", BCrypt.gensalt()),
+              "this is a test biography",
               Instant.now());
       PersistentStorageAgent.getInstance().writeThrough(user);
       users.add(user);

--- a/src/main/java/codeu/model/store/basic/MessageStore.java
+++ b/src/main/java/codeu/model/store/basic/MessageStore.java
@@ -102,6 +102,19 @@ public class MessageStore {
     return messages;
   }
 
+  /** Access the content of the most recent message within a given conversation */
+  public String getMostRecentMessageFromConvo(UUID conversationId) {
+
+    String recentMessage = "";
+    messages.sort(msgComparator);
+
+    for (Message message : messages) {
+      if (message.getConversationId().equals(conversationId)) recentMessage = message.getContent();
+      break;
+    }
+    return recentMessage;
+  }
+
   /** Access the current set of Messages within the given Conversation. */
   public List<Message> getMessagesInConversation(UUID conversationId) {
 

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -64,8 +64,9 @@ public class UserStore {
     users = new ArrayList<>();
   }
 
-  /** Load a set of randomly-generated Message objects. */
+  /** Load a set of randomly-generated Users objects. */
   public void loadTestData() {
+    System.out.println("test");
     users.addAll(DefaultDataStore.getInstance().getAllUsers());
   }
 

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -14,6 +14,7 @@
 
 package codeu.model.store.persistence;
 
+import codeu.model.data.Activity;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
@@ -149,6 +150,44 @@ public class PersistentDataStore {
     return messages;
   }
 
+  /**
+   * Loads all Activity objects from the Datastore service and returns them in a List.
+   *
+   * @throws codeu.model.store.persistence.PersistentDataStoreException if an error was detected
+   *     during the load from the Datastore service
+   */
+  public List<Activity> loadActivities() throws PersistentDataStoreException {
+
+    List<Activity> activities = new ArrayList<>();
+
+    // Retrieve all activities from the datastore.
+    Query query = new Query("chat-activities");
+    PreparedQuery results = datastore.prepare(query);
+
+    for (Entity entity : results.asIterable()) {
+      try {
+        UUID uuid = UUID.fromString((String) entity.getProperty("uuid"));
+        UUID memberId = UUID.fromString((String) entity.getProperty("member_id"));
+        UUID conversationId = UUID.fromString((String) entity.getProperty("conversation_id"));
+        Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
+        String activityType = (String) entity.getProperty("activity_type");
+        String activityMessage = (String) entity.getProperty("activity_message");
+
+        Activity activity =
+            new Activity(
+                uuid, memberId, conversationId, creationTime, activityType, activityMessage);
+        activities.add(activity);
+      } catch (Exception e) {
+        // In a production environment, errors should be very rare. Errors which may
+        // occur include network errors, Datastore service errors, authorization errors,
+        // database entity definition mismatches, or service mismatches.
+        throw new PersistentDataStoreException(e);
+      }
+    }
+
+    return activities;
+  }
+
   /** Write a User object to the Datastore service. */
   public void writeThrough(User user) {
     Entity userEntity = new Entity("chat-users");
@@ -178,5 +217,18 @@ public class PersistentDataStore {
     conversationEntity.setProperty("title", conversation.getTitle());
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
     datastore.put(conversationEntity);
+  }
+
+  /** Write an Activity object to the Datastore service. */
+  public void writeThrough(Activity activity) {
+    Entity activityEntity = new Entity("chat-activities");
+    activityEntity.setProperty("uuid", activity.getId().toString());
+    activityEntity.setProperty("member_id", activity.getUserId().toString());
+    activityEntity.setProperty("conversation_id", activity.getConversationId().toString());
+    activityEntity.setProperty("creation_time", activity.getCreationTime().toString());
+    activityEntity.setProperty("activity_type", activity.getActivityType());
+    activityEntity.setProperty("activity_message", activity.getActivityMessage());
+
+    datastore.put(activityEntity);
   }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -66,7 +66,10 @@ public class PersistentDataStore {
         UUID uuid = UUID.fromString((String) entity.getProperty("uuid"));
         String userName = (String) entity.getProperty("username");
         String password = (String) entity.getProperty("password");
-        String biography = (String) entity.getProperty("biography");  //I'm not sure what this Entity business is, hope this works?
+        String biography =
+            (String)
+                entity.getProperty(
+                    "biography"); // I'm not sure what this Entity business is, hope this works?
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
         if (password != null && !password.startsWith("$2a$")) {
           password = BCrypt.hashpw(password, BCrypt.gensalt());

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -66,11 +66,12 @@ public class PersistentDataStore {
         UUID uuid = UUID.fromString((String) entity.getProperty("uuid"));
         String userName = (String) entity.getProperty("username");
         String password = (String) entity.getProperty("password");
+        String biography = (String) entity.getProperty("biography");  //I'm not sure what this Entity business is, hope this works?
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
         if (password != null && !password.startsWith("$2a$")) {
           password = BCrypt.hashpw(password, BCrypt.gensalt());
         }
-        User user = new User(uuid, userName, password, creationTime);
+        User user = new User(uuid, userName, password, biography, creationTime);
         users.add(user);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -14,6 +14,7 @@
 
 package codeu.model.store.persistence;
 
+import codeu.model.data.Activity;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
@@ -88,6 +89,16 @@ public class PersistentStorageAgent {
     return persistentDataStore.loadMessages();
   }
 
+  /**
+   * Retrieve all Activity objects from the Datastore service. The returned list may be empty.
+   *
+   * @throws PersistentDataStoreException if an error was detected during the load from the
+   *     Datastore service
+   */
+  public List<Activity> loadActivities() throws PersistentDataStoreException {
+    return persistentDataStore.loadActivities();
+  }
+
   /** Write a User object to the Datastore service. */
   public void writeThrough(User user) {
     persistentDataStore.writeThrough(user);
@@ -101,5 +112,10 @@ public class PersistentStorageAgent {
   /** Write a Conversation object to the Datastore service. */
   public void writeThrough(Message message) {
     persistentDataStore.writeThrough(message);
+  }
+
+  /** Write an Activity object to the Datastore service */
+  public void writeThrough(Activity activity) {
+    persistentDataStore.writeThrough(activity);
   }
 }

--- a/src/main/webapp/WEB-INF/view/activityFeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityFeed.jsp
@@ -2,6 +2,7 @@
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
 <%@ page import="codeu.model.data.User" %>
+<%@ page import="codeu.model.data.Activity" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
 <%@ page import="codeu.model.store.basic.MessageStore" %>
 <%@ page import="codeu.model.store.basic.ConversationStore" %>
@@ -10,7 +11,7 @@
 <%@ page import="java.util.UUID" %>
 
 <%
-List<Message> messages = (List<Message>) request.getAttribute("messages");
+List<Activity> activities = (List<Activity>) request.getAttribute("activities");
 %>
 
 <!DOCTYPE html>
@@ -52,23 +53,18 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
     <div id="activity">
       <ul>
         <%
-          for (Message message : messages) {
-            UUID userId = message.getAuthorId();
-            String userName = UserStore.getInstance().getUser(userId).getName();
-            String content = message.getContent();
-            UUID conversationId = message.getConversationId();
-            String conversationName = ConversationStore.getInstance().getConversationWithId(conversationId).getTitle();
-
-            Instant creationTime = message.getCreationTime();
+          for ( Activity activity : activities) {
+            String type = activity.getActivityType();
+            Instant creationTime = activity.getCreationTime();
             LocalDateTime ldt = LocalDateTime.ofInstant(creationTime, ZoneId.systemDefault());
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yy h:mm:ss a");
             String time = ldt.format(formatter);
-         %>
-         <li>
-           <strong><%= time %>:</strong>
-              <%= userName + " sent a message to " + conversationName + ": " %>
-              <q><%= content %></q>
-         </li>
+        %>
+        <li>
+          <strong><%= time %>:</strong>
+          <% if (type == "joinedApp") %>
+          <%= activity.getActivityMessage() %>
+        </li>
          <%
           }
          %>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -13,7 +13,6 @@
 <%@ page import="java.util.List" %>
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
-<%@ page import="codeu.model.data.User" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
 <%@ page import="codeu.model.data.User" %>
 <%
@@ -88,14 +87,7 @@ User user = (User) UserStore.getInstance().getUser((String) request.getSession()
       <h2 style="color:red"><%= request.getAttribute("error") %></h2>
     <% } %>
 
-<<<<<<< HEAD
     <% if (user != null && conversationUsers.contains(user)) { %>
-||||||| merged common ancestors
-    <% if (request.getSession().getAttribute("user") != null && conversationUsers.contains(request.getSession().getAttribute("user")) { %>
-=======
-    <% if (request.getSession().getAttribute("user") != null && conversationUsers.contains(request.getSession()
-    .getAttribute("user"))) { %>
->>>>>>> 74ed601bdcd96513b0834584170866cb9823321a
     <form id="chatform" action="/chat/<%= conversation.getTitle() %>" method="POST">
         <textarea name="message"></textarea>
         </br>
@@ -103,19 +95,8 @@ User user = (User) UserStore.getInstance().getUser((String) request.getSession()
         </br>
         <button type="submit" name="button" value="leaveButton">Leave Conversation</button>
     </form>
-<<<<<<< HEAD
     <% } else if (user != null && !(conversationUsers.contains(user))) { %>
     <p> Join the conversation to send a message! </p>
-||||||| merged common ancestors
-    <% } %>
-
-    <% if (request.getAttribute("user") != null && !(conversationUsers.contains(request.getSession().getAttribute("user"))) { %>
-=======
-    <% } %>
-
-    <% if (request.getAttribute("user") != null && !(conversationUsers.contains(request.getSession().getAttribute
-    ("user")))){ %>
->>>>>>> 74ed601bdcd96513b0834584170866cb9823321a
     <form id="chatform" action="/chat/<%= conversation.getTitle() %>" method="POST">
             <button type="submit" name="button" value="joinButton">Join Conversation</button>
     </form>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -13,6 +13,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
+<%@ page import="codeu.model.data.User" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
 <%@ page import="codeu.model.data.User" %>
 <%
@@ -87,7 +88,14 @@ User user = (User) UserStore.getInstance().getUser((String) request.getSession()
       <h2 style="color:red"><%= request.getAttribute("error") %></h2>
     <% } %>
 
+<<<<<<< HEAD
     <% if (user != null && conversationUsers.contains(user)) { %>
+||||||| merged common ancestors
+    <% if (request.getSession().getAttribute("user") != null && conversationUsers.contains(request.getSession().getAttribute("user")) { %>
+=======
+    <% if (request.getSession().getAttribute("user") != null && conversationUsers.contains(request.getSession()
+    .getAttribute("user"))) { %>
+>>>>>>> 74ed601bdcd96513b0834584170866cb9823321a
     <form id="chatform" action="/chat/<%= conversation.getTitle() %>" method="POST">
         <textarea name="message"></textarea>
         </br>
@@ -95,8 +103,19 @@ User user = (User) UserStore.getInstance().getUser((String) request.getSession()
         </br>
         <button type="submit" name="button" value="leaveButton">Leave Conversation</button>
     </form>
+<<<<<<< HEAD
     <% } else if (user != null && !(conversationUsers.contains(user))) { %>
     <p> Join the conversation to send a message! </p>
+||||||| merged common ancestors
+    <% } %>
+
+    <% if (request.getAttribute("user") != null && !(conversationUsers.contains(request.getSession().getAttribute("user"))) { %>
+=======
+    <% } %>
+
+    <% if (request.getAttribute("user") != null && !(conversationUsers.contains(request.getSession().getAttribute
+    ("user")))){ %>
+>>>>>>> 74ed601bdcd96513b0834584170866cb9823321a
     <form id="chatform" action="/chat/<%= conversation.getTitle() %>" method="POST">
             <button type="submit" name="button" value="joinButton">Join Conversation</button>
     </form>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -48,12 +48,12 @@ User user = (User) request.getAttribute("user");
   <h1 align ="center"><%= user.getName() %>'s Profile</h1>
   <div id="container">
   <h2>Biography</h2>
-    <% if (user.getBio() != null) { 
-         user.getBio(); %>
-     } else {%>
+    <% if (user.getBio() != null) { %>
+        <%= user.getBio() %>
+    <% } else { %>
         <p> This user has not yet set up their biography! </p>
-     <% } %>
-    <% if (request.getSession().getAttribute("user") == user) { //Right now, this condition executes even if not logged in!
+     <% }
+     if (request.getSession().getAttribute("user").equals(user.getName())) {
      %>
      <p> You can change your biography below: </p>
      <form action='' user method="POST">

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -47,6 +47,26 @@ User user = (User) request.getAttribute("user");
   <body onload="scrollChat()">
   <h1 align ="center"><%= user.getName() %>'s Profile</h1>
   <div id="container">
+  <h2>Biography</h2>
+    <% if (user.getBio() != null) { 
+         user.getBio(); %>
+     } else {%>
+        <p> This user has not yet set up their biography! </p>
+     <% } %>
+    <% if (request.getSession().getAttribute("user") == user) { //Right now, this condition executes even if not logged in!
+     %>
+     <p> You can change your biography below: </p>
+     <form action='' user method="POST">
+       <label for="newBio">New Bio: </label>
+       <input type="text" name="newBio" id="newBio">
+       <button type="submit">Submit</button> 
+  </form>
+  <% } %>
+    <br>
+    <br>
+  
+  </div>
+  <div id="container">
    <h2>Sent Messages</h2>
    <div id="messages">
      <ul>

--- a/src/main/webapp/WEB-INF/view/register.jsp
+++ b/src/main/webapp/WEB-INF/view/register.jsp
@@ -25,13 +25,13 @@
    <a href="/about.jsp">About</a>
  </nav>
   <div id="container">
-  	<h1>Register</h1>
+    <h1>Register</h1>
 
     <% if(request.getAttribute("error") != null){ %>
        <h2 style="color:red"><%= request.getAttribute("error") %></h2>
     <% } %>
 
-  	<form action="/register" method="POST">
+    <form action="/register" method="POST">
       <label for="username">Username: </label>
       <input type="text" name="username" id="username">
       <br/>
@@ -43,7 +43,7 @@
       <br/>
       <br/><br/>
       <button type="submit">Submit</button>
-   	</form>
+    </form>
   </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/view/testdata.jsp
+++ b/src/main/webapp/WEB-INF/view/testdata.jsp
@@ -34,20 +34,6 @@
 </head>
 <body>
 
-
-<nav>
-   <a id="navTitle" href="/">CodeU Chat App</a>
-   <a href="/conversations">Conversations</a>
-   <% if(request.getSession().getAttribute("user") != null){ %>
-     <a>Hello <%= request.getSession().getAttribute("user") %>!</a>
-   <% } else{ %>
-     <a href="/login">Login</a>
-     <a href="/register">Register</a>
-   <% } %>
-   <a href="/about.jsp">About</a>
- </nav>
-
-
   <div id="container">
     <h1>Load Test Data</h1>
     <p>This will load a number of users, conversations, and messages for testing

--- a/src/test/java/codeu/controller/ActivityServletTest.java
+++ b/src/test/java/codeu/controller/ActivityServletTest.java
@@ -1,9 +1,7 @@
 package codeu.controller;
 
-import codeu.model.data.Message;
-import codeu.model.store.basic.ConversationStore;
-import codeu.model.store.basic.MessageStore;
-import codeu.model.store.basic.UserStore;
+import codeu.model.data.Activity;
+import codeu.model.store.basic.ActivityStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -25,9 +23,7 @@ public class ActivityServletTest {
   private HttpServletRequest mockRequest;
   private HttpServletResponse mockResponse;
   private RequestDispatcher mockRequestDispatcher;
-  private ConversationStore mockConversationStore;
-  private MessageStore mockMessageStore;
-  private UserStore mockUserStore;
+  private ActivityStore mockActivityStore;
 
   @Before
   public void setup() {
@@ -42,40 +38,37 @@ public class ActivityServletTest {
     Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/activityFeed.jsp"))
         .thenReturn(mockRequestDispatcher);
 
-    mockMessageStore = Mockito.mock(MessageStore.class);
-    activityServlet.setMessageStore(mockMessageStore);
-
-    mockUserStore = Mockito.mock(UserStore.class);
-    activityServlet.setUserStore(mockUserStore);
-
-    mockConversationStore = Mockito.mock(ConversationStore.class);
-    activityServlet.setConversationStore(mockConversationStore);
+    mockActivityStore = Mockito.mock(ActivityStore.class);
+    activityServlet.setActivityStore(mockActivityStore);
   }
 
   @Test
   public void testDoGet() throws IOException, ServletException {
 
-    List<Message> sampleMessages = new ArrayList<>();
-    sampleMessages.add(
-        new Message(
+    List<Activity> sampleActivities = new ArrayList<>();
+    sampleActivities.add(
+        new Activity(
             UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID(),
-            "test message 1",
-            Instant.ofEpochMilli(2000)));
-    sampleMessages.add(
-        new Message(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            "test message 2",
-            Instant.ofEpochMilli(1000)));
+            Instant.ofEpochMilli(2000),
+            "joinedApp",
+            "testMessage"));
 
-    Mockito.when(mockMessageStore.getAllMessages()).thenReturn(sampleMessages);
+    sampleActivities.add(
+        new Activity(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            Instant.ofEpochMilli(1000),
+            "createdConvo",
+            "testMessage"));
+
+    Mockito.when(mockActivityStore.getAllActivities()).thenReturn(sampleActivities);
 
     activityServlet.doGet(mockRequest, mockResponse);
 
-    Mockito.verify(mockRequest).setAttribute("messages", sampleMessages);
+    Mockito.verify(mockRequest).setAttribute("activities", sampleActivities);
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 }

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -135,7 +135,7 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
@@ -152,7 +152,7 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -178,7 +178,7 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -206,7 +206,7 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -225,7 +225,7 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -251,7 +251,7 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio",Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -277,7 +277,7 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -135,7 +135,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
@@ -152,7 +153,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -178,7 +180,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -206,7 +209,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -225,7 +229,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -251,7 +256,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio",Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
@@ -277,7 +283,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "testbio", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -105,7 +105,7 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     conversationServlet.doPost(mockRequest, mockResponse);
@@ -121,7 +121,7 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("bad !@#$% name");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     conversationServlet.doPost(mockRequest, mockResponse);
@@ -137,7 +137,7 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(true);
@@ -154,7 +154,7 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(false);

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -105,7 +105,8 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     conversationServlet.doPost(mockRequest, mockResponse);
@@ -121,7 +122,8 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("bad !@#$% name");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     conversationServlet.doPost(mockRequest, mockResponse);
@@ -137,7 +139,8 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(true);
@@ -154,7 +157,8 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
+    User fakeUser =
+        new User(UUID.randomUUID(), "test_username", "password", "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(false);

--- a/src/test/java/codeu/controller/LoginServletTest.java
+++ b/src/test/java/codeu/controller/LoginServletTest.java
@@ -78,7 +78,7 @@ public class LoginServletTest {
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test_username")).thenReturn(true);
     String hashedPassword = BCrypt.hashpw("password", BCrypt.gensalt());
-    User testUser = new User(UUID.randomUUID(), "test_username", hashedPassword, Instant.now());
+    User testUser = new User(UUID.randomUUID(), "test_username", hashedPassword, "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(testUser);
     loginServlet.setUserStore(mockUserStore);
 
@@ -101,7 +101,7 @@ public class LoginServletTest {
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test_username")).thenReturn(true);
     String hashedPassword = BCrypt.hashpw("password", BCrypt.gensalt());
-    User testUser = new User(UUID.randomUUID(), "test_username", hashedPassword, Instant.now());
+    User testUser = new User(UUID.randomUUID(), "test_username", hashedPassword, "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(testUser);
     loginServlet.setUserStore(mockUserStore);
 

--- a/src/test/java/codeu/controller/LoginServletTest.java
+++ b/src/test/java/codeu/controller/LoginServletTest.java
@@ -78,7 +78,9 @@ public class LoginServletTest {
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test_username")).thenReturn(true);
     String hashedPassword = BCrypt.hashpw("password", BCrypt.gensalt());
-    User testUser = new User(UUID.randomUUID(), "test_username", hashedPassword, "test biography", Instant.now());
+    User testUser =
+        new User(
+            UUID.randomUUID(), "test_username", hashedPassword, "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(testUser);
     loginServlet.setUserStore(mockUserStore);
 
@@ -101,7 +103,9 @@ public class LoginServletTest {
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test_username")).thenReturn(true);
     String hashedPassword = BCrypt.hashpw("password", BCrypt.gensalt());
-    User testUser = new User(UUID.randomUUID(), "test_username", hashedPassword, "test biography", Instant.now());
+    User testUser =
+        new User(
+            UUID.randomUUID(), "test_username", hashedPassword, "test biography", Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(testUser);
     loginServlet.setUserStore(mockUserStore);
 

--- a/src/test/java/codeu/controller/ProfileServletTest.java
+++ b/src/test/java/codeu/controller/ProfileServletTest.java
@@ -57,7 +57,7 @@ public class ProfileServletTest {
   public void testDoGet() throws IOException, ServletException {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/profile/test_user");
 
-    User testUser = new User(UUID.randomUUID(), "test_user", "password", Instant.now());
+    User testUser = new User(UUID.randomUUID(), "test_user", "password", null, Instant.now());
     Mockito.when(mockUserStore.getUser("test_user")).thenReturn(testUser);
 
     List<Message> fakeMessageList = new ArrayList<>();

--- a/src/test/java/codeu/controller/RegisterServletTest.java
+++ b/src/test/java/codeu/controller/RegisterServletTest.java
@@ -1,6 +1,8 @@
 package codeu.controller;
 
+import codeu.model.data.Activity;
 import codeu.model.data.User;
+import codeu.model.store.basic.ActivityStore;
 import codeu.model.store.basic.UserStore;
 import java.io.IOException;
 import javax.servlet.RequestDispatcher;
@@ -59,15 +61,23 @@ public class RegisterServletTest {
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(false);
     registerServlet.setUserStore(mockUserStore);
 
+    ActivityStore mockActivityStore = Mockito.mock(ActivityStore.class);
+    registerServlet.setActivityStore(mockActivityStore);
+
     HttpSession mockSession = Mockito.mock(HttpSession.class);
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
 
     registerServlet.doPost(mockRequest, mockResponse);
 
     ArgumentCaptor<User> userArgumentCaptor = ArgumentCaptor.forClass(User.class);
+    ArgumentCaptor<Activity> activityArgumentCaptor = ArgumentCaptor.forClass(Activity.class);
 
     Mockito.verify(mockUserStore).addUser(userArgumentCaptor.capture());
     Assert.assertEquals(userArgumentCaptor.getValue().getName(), "test username");
+
+    Mockito.verify(mockActivityStore).addActivity(activityArgumentCaptor.capture());
+    Assert.assertEquals(
+        activityArgumentCaptor.getValue().getUserId(), userArgumentCaptor.getValue().getId());
 
     Mockito.verify(mockResponse).sendRedirect("/login");
   }
@@ -82,6 +92,9 @@ public class RegisterServletTest {
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(true);
     registerServlet.setUserStore(mockUserStore);
 
+    ActivityStore mockActivityStore = Mockito.mock(ActivityStore.class);
+    registerServlet.setActivityStore(mockActivityStore);
+
     HttpSession mockSession = Mockito.mock(HttpSession.class);
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
 
@@ -90,6 +103,7 @@ public class RegisterServletTest {
     Mockito.verify(mockRequest).setAttribute("error", "That username is already taken.");
 
     Mockito.verify(mockUserStore, Mockito.never()).addUser(Mockito.any(User.class));
+    Mockito.verify(mockActivityStore, Mockito.never()).addActivity(Mockito.any(Activity.class));
   }
 
   @Test

--- a/src/test/java/codeu/controller/TestDataServletTest.java
+++ b/src/test/java/codeu/controller/TestDataServletTest.java
@@ -14,6 +14,7 @@
 
 package codeu.controller;
 
+import codeu.model.store.basic.ActivityStore;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
@@ -37,6 +38,7 @@ public class TestDataServletTest {
   private ConversationStore mockConversationStore;
   private MessageStore mockMessageStore;
   private UserStore mockUserStore;
+  private ActivityStore mockActivityStore;
 
   @Before
   public void setup() {
@@ -59,6 +61,9 @@ public class TestDataServletTest {
 
     mockUserStore = Mockito.mock(UserStore.class);
     testDataServlet.setUserStore(mockUserStore);
+
+    mockActivityStore = Mockito.mock(ActivityStore.class);
+    testDataServlet.setActivityStore(mockActivityStore);
   }
 
   @Test
@@ -77,6 +82,7 @@ public class TestDataServletTest {
     Mockito.verify(mockUserStore).loadTestData();
     Mockito.verify(mockConversationStore).loadTestData();
     Mockito.verify(mockMessageStore).loadTestData();
+    Mockito.verify(mockActivityStore).loadTestData();
     Mockito.verify(mockResponse).sendRedirect("/");
   }
 
@@ -90,6 +96,7 @@ public class TestDataServletTest {
     Mockito.verify(mockUserStore, Mockito.never()).loadTestData();
     Mockito.verify(mockConversationStore, Mockito.never()).loadTestData();
     Mockito.verify(mockMessageStore, Mockito.never()).loadTestData();
+    Mockito.verify(mockActivityStore, Mockito.never()).loadTestData();
     Mockito.verify(mockResponse).sendRedirect("/");
   }
 }

--- a/src/test/java/codeu/model/data/ActivityTest.java
+++ b/src/test/java/codeu/model/data/ActivityTest.java
@@ -1,0 +1,42 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.model.data;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ActivityTest {
+
+  @Test
+  public void testCreate() {
+
+    UUID id = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    UUID conversationId = UUID.randomUUID();
+    Instant creation = Instant.now();
+    String activityType = "messageSent";
+    String message = "testMessage";
+
+    Activity activity = new Activity(id, userId, conversationId, creation, activityType, message);
+
+    Assert.assertEquals(id, activity.getId());
+    Assert.assertEquals(userId, activity.getUserId());
+    Assert.assertEquals(conversationId, activity.getConversationId());
+    Assert.assertEquals(creation, activity.getCreationTime());
+    Assert.assertEquals(activityType, activity.getActivityType());
+  }
+}

--- a/src/test/java/codeu/model/data/UserTest.java
+++ b/src/test/java/codeu/model/data/UserTest.java
@@ -26,13 +26,15 @@ public class UserTest {
     UUID id = UUID.randomUUID();
     String name = "test_username";
     String password = "password";
+    String biography = "test biography right here";
     Instant creation = Instant.now();
 
-    User user = new User(id, name, password, creation);
+    User user = new User(id, name, password, biography, creation);
 
     Assert.assertEquals(id, user.getId());
     Assert.assertEquals(name, user.getName());
     Assert.assertEquals(password, user.getPassword());
+    Assert.assertEquals(biography, user.getBio());
     Assert.assertEquals(creation, user.getCreationTime());
   }
 }

--- a/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
@@ -1,0 +1,81 @@
+package codeu.model.store.basic;
+
+import codeu.model.data.Activity;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ActivityStoreTest {
+
+  private ActivityStore activityStore;
+  private PersistentStorageAgent mockPersistentStorageAgent;
+
+  private final Activity ACTIVITY_ONE =
+      new Activity(
+          UUID.randomUUID(),
+          UUID.randomUUID(),
+          UUID.randomUUID(),
+          Instant.ofEpochMilli(1000),
+          "leftConvo",
+          "test_message");
+
+  @Before
+  public void setup() {
+    mockPersistentStorageAgent = Mockito.mock(PersistentStorageAgent.class);
+    activityStore = ActivityStore.getTestInstance(mockPersistentStorageAgent);
+
+    final List<Activity> activityList = new ArrayList<>();
+    activityList.add(ACTIVITY_ONE);
+    activityStore.setActivities(activityList);
+  }
+
+  @Test
+  public void testGetActivityWithId_found() {
+    Activity resultActivity = activityStore.getActivityWithId(ACTIVITY_ONE.getId());
+
+    assertEquals(ACTIVITY_ONE, resultActivity);
+  }
+
+  @Test
+  public void testGetActivityWithId_notFound() {
+    // Generates an empty/nil UUID object
+    UUID uuid = new UUID(0L, 0L);
+    Activity resultActivity = activityStore.getActivityWithId(uuid);
+
+    Assert.assertNull(resultActivity);
+  }
+
+  @Test
+  public void testAddActivity() {
+    UUID activtiyId = UUID.randomUUID();
+    Activity inputActivity =
+        new Activity(
+            activtiyId,
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            Instant.now(),
+            "joinedConvo",
+            "testMessage");
+
+    activityStore.addActivity(inputActivity);
+    Activity resultActivity = activityStore.getActivityWithId(activtiyId);
+
+    assertEquals(inputActivity, resultActivity);
+    Mockito.verify(mockPersistentStorageAgent).writeThrough(inputActivity);
+  }
+
+  private void assertEquals(Activity expectedActivity, Activity actualActivity) {
+    Assert.assertEquals(expectedActivity.getId(), actualActivity.getId());
+    Assert.assertEquals(expectedActivity.getUserId(), actualActivity.getUserId());
+    Assert.assertEquals(expectedActivity.getConversationId(), actualActivity.getConversationId());
+    Assert.assertEquals(expectedActivity.getCreationTime(), actualActivity.getCreationTime());
+    Assert.assertEquals(expectedActivity.getActivityType(), actualActivity.getActivityType());
+    Assert.assertEquals(expectedActivity.getActivityMessage(), actualActivity.getActivityMessage());
+  }
+}

--- a/src/test/java/codeu/model/store/basic/UserStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/UserStoreTest.java
@@ -17,12 +17,18 @@ public class UserStoreTest {
   private PersistentStorageAgent mockPersistentStorageAgent;
 
   private final User USER_ONE =
-      new User(UUID.randomUUID(), "test_username_one", "password one", null, Instant.ofEpochMilli(1000));
+      new User(
+          UUID.randomUUID(), "test_username_one", "password one", null, Instant.ofEpochMilli(1000));
   private final User USER_TWO =
-      new User(UUID.randomUUID(), "test_username_two", "password two", null, Instant.ofEpochMilli(2000));
+      new User(
+          UUID.randomUUID(), "test_username_two", "password two", null, Instant.ofEpochMilli(2000));
   private final User USER_THREE =
       new User(
-          UUID.randomUUID(), "test_username_three", "password three", null, Instant.ofEpochMilli(3000));
+          UUID.randomUUID(),
+          "test_username_three",
+          "password three",
+          null,
+          Instant.ofEpochMilli(3000));
 
   @Before
   public void setup() {

--- a/src/test/java/codeu/model/store/basic/UserStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/UserStoreTest.java
@@ -17,12 +17,12 @@ public class UserStoreTest {
   private PersistentStorageAgent mockPersistentStorageAgent;
 
   private final User USER_ONE =
-      new User(UUID.randomUUID(), "test_username_one", "password one", Instant.ofEpochMilli(1000));
+      new User(UUID.randomUUID(), "test_username_one", "password one", null, Instant.ofEpochMilli(1000));
   private final User USER_TWO =
-      new User(UUID.randomUUID(), "test_username_two", "password two", Instant.ofEpochMilli(2000));
+      new User(UUID.randomUUID(), "test_username_two", "password two", null, Instant.ofEpochMilli(2000));
   private final User USER_THREE =
       new User(
-          UUID.randomUUID(), "test_username_three", "password three", Instant.ofEpochMilli(3000));
+          UUID.randomUUID(), "test_username_three", "password three", null, Instant.ofEpochMilli(3000));
 
   @Before
   public void setup() {
@@ -66,7 +66,7 @@ public class UserStoreTest {
 
   @Test
   public void testAddUser() {
-    User inputUser = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User inputUser = new User(UUID.randomUUID(), "test_username", "password", null, Instant.now());
 
     userStore.addUser(inputUser);
     User resultUser = userStore.getUser("test_username");

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -44,13 +44,13 @@ public class PersistentDataStoreTest {
     String nameOne = "test_username_one";
     String passwordOne = "test_password_one";
     Instant creationOne = Instant.ofEpochMilli(1000);
-    User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne);
+    User inputUserOne = new User(idOne, nameOne, passwordOne, null, creationOne);
 
     UUID idTwo = UUID.randomUUID();
     String nameTwo = "test_username_two";
     String passwordTwo = "test_password_two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, creationTwo);
+    User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, null, creationTwo);
 
     // save
     persistentDataStore.writeThrough(inputUserOne);
@@ -80,14 +80,14 @@ public class PersistentDataStoreTest {
     String passwordOne = "test_password_one";
     String hashedPasswordOne = BCrypt.hashpw(passwordOne, BCrypt.gensalt());
     Instant creationOne = Instant.ofEpochMilli(1000);
-    User inputUserOne = new User(idOne, nameOne, hashedPasswordOne, creationOne);
+    User inputUserOne = new User(idOne, nameOne, hashedPasswordOne, null, creationOne);
 
     UUID idTwo = UUID.randomUUID();
     String nameTwo = "test_username_two";
     String passwordTwo = "test_password_two";
     String hashedPasswordTwo = BCrypt.hashpw(passwordTwo, BCrypt.gensalt());
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    User inputUserTwo = new User(idTwo, nameTwo, hashedPasswordTwo, creationTwo);
+    User inputUserTwo = new User(idTwo, nameTwo, hashedPasswordTwo, null, creationTwo);
 
     // save
     persistentDataStore.writeThrough(inputUserOne);

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -1,5 +1,6 @@
 package codeu.model.store.persistence;
 
+import codeu.model.data.Activity;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
@@ -183,5 +184,51 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(authorTwo, resultMessageTwo.getAuthorId());
     Assert.assertEquals(contentTwo, resultMessageTwo.getContent());
     Assert.assertEquals(creationTwo, resultMessageTwo.getCreationTime());
+  }
+
+  @Test
+  public void testSaveAndLoadActivities() throws PersistentDataStoreException {
+    UUID idOne = UUID.randomUUID();
+    UUID userIdOne = UUID.randomUUID();
+    UUID conversationIdOne = UUID.randomUUID();
+    Instant creationOne = Instant.ofEpochMilli(1000);
+    String messageTypeOne = "joinedApp";
+    String messageOne = "Ada joined!";
+    Activity inputActivityOne =
+        new Activity(idOne, userIdOne, conversationIdOne, creationOne, messageTypeOne, messageOne);
+
+    UUID idTwo = UUID.randomUUID();
+    UUID userIdTwo = UUID.randomUUID();
+    UUID conversationIdTwo = UUID.randomUUID();
+    Instant creationTwo = Instant.ofEpochMilli(1000);
+    String messageTypeTwo = "messageSent";
+    String messageTwo =
+        "Grace sent a message in Programming Chat: \"I've always been more interested "
+            + "in the future than in the past.\"";
+    Activity inputActivityTwo =
+        new Activity(idTwo, userIdTwo, conversationIdTwo, creationTwo, messageTypeTwo, messageTwo);
+    // save
+    persistentDataStore.writeThrough(inputActivityOne);
+    persistentDataStore.writeThrough(inputActivityTwo);
+
+    // load
+    List<Activity> resultActivities = persistentDataStore.loadActivities();
+
+    // confirm that what we saved matches what we loaded
+    Activity resultActivityOne = resultActivities.get(0);
+    Assert.assertEquals(idOne, resultActivityOne.getId());
+    Assert.assertEquals(userIdOne, resultActivityOne.getUserId());
+    Assert.assertEquals(conversationIdOne, resultActivityOne.getConversationId());
+    Assert.assertEquals(creationOne, resultActivityOne.getCreationTime());
+    Assert.assertEquals(messageTypeOne, resultActivityOne.getActivityType());
+    Assert.assertEquals(messageOne, resultActivityOne.getActivityMessage());
+
+    Activity resultActivityTwo = resultActivities.get(1);
+    Assert.assertEquals(idTwo, resultActivityTwo.getId());
+    Assert.assertEquals(userIdTwo, resultActivityTwo.getUserId());
+    Assert.assertEquals(conversationIdTwo, resultActivityTwo.getConversationId());
+    Assert.assertEquals(creationTwo, resultActivityTwo.getCreationTime());
+    Assert.assertEquals(messageTypeTwo, resultActivityTwo.getActivityType());
+    Assert.assertEquals(messageTwo, resultActivityTwo.getActivityMessage());
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -1,5 +1,6 @@
 package codeu.model.store.persistence;
 
+import codeu.model.data.Activity;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
@@ -45,6 +46,12 @@ public class PersistentStorageAgentTest {
   }
 
   @Test
+  public void testLoadActivities() throws PersistentDataStoreException {
+    persistentStorageAgent.loadActivities();
+    Mockito.verify(mockPersistentDataStore).loadActivities();
+  }
+
+  @Test
   public void testWriteThroughUser() {
     User user = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
     persistentStorageAgent.writeThrough(user);
@@ -66,5 +73,19 @@ public class PersistentStorageAgentTest {
             UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "test content", Instant.now());
     persistentStorageAgent.writeThrough(message);
     Mockito.verify(mockPersistentDataStore).writeThrough(message);
+  }
+
+  @Test
+  public void testWriteThroughActivity() {
+    Activity activity =
+        new Activity(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            Instant.now(),
+            "messageSent",
+            "sampleMessage");
+    persistentStorageAgent.writeThrough(activity);
+    Mockito.verify(mockPersistentDataStore).writeThrough(activity);
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -53,7 +53,7 @@ public class PersistentStorageAgentTest {
 
   @Test
   public void testWriteThroughUser() {
-    User user = new User(UUID.randomUUID(), "test_username", "password", Instant.now());
+    User user = new User(UUID.randomUUID(), "test_username", "password", null, Instant.now());
     persistentStorageAgent.writeThrough(user);
     Mockito.verify(mockPersistentDataStore).writeThrough(user);
   }


### PR DESCRIPTION
Added required classes and tests to allow for activities to be persisted. Then instead of generating all activities each time around, in activityFeed.jsp we can just iterate through a list of activities and display them as needed. Also added the ability to generate sample test data activities to use.
Currently, only the user joined activities are visible but the rest will be added in the next pull request.

Alison edited the profile page to allow users to add and edit biographies for their own pages. 

Sorry that this pull request got kind of massive! 
