### PR TITLE
Conditionally disable the integration test in Java 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,21 +4,16 @@
 #
 version: 2
 jobs:
-  build:
+  build-java8: &build
     docker:
       # specify the version you desire here
       - image: circleci/openjdk:8-jdk
-      
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
 
     environment:
       MAVEN_OPTS: -Xmx3200m
-    
+
     steps:
       - checkout
 
@@ -38,6 +33,18 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-        
+
       # run tests!
       - run: mvn integration-test
+
+  build-java9:
+    << : *build
+    docker:
+      - image: circleci/openjdk:9-jdk
+
+workflows:
+  version: 2
+  build_both_versions:
+    jobs:
+      - build-java8
+      - build-java9

--- a/src/test/java/codeu/integration/ProfileIntegrationTest.java
+++ b/src/test/java/codeu/integration/ProfileIntegrationTest.java
@@ -42,6 +42,13 @@ public class ProfileIntegrationTest {
 
   @Test
   public void testGetProfile_NoUser() throws IOException, SAXException {
+    // HttpUnit 1.7.2 (the latest version) requires servlets 2.4, which
+    // requires Jasper 6, which does not support Java 9.
+    if (System.getProperty("java.version").startsWith("9.")) {
+      System.err.println("Skipping integration test due to Java 9.");
+      return;
+    }
+
     WebRequest request = new GetMethodWebRequest("http://dummy/profile/dummy_user");
     WebResponse response = servletClient.getResponse(request);
 


### PR DESCRIPTION
I couldn't find a great way to add Java 9 support with the ServletTest support in HttpUnit. As best I can tell, HttpUnit only supports Jasper 6.0, which was last updated a year ago, and seems to cause the ClassLoader problems @mariezimmy was running into.

While we were here, I also enabled automatic Java 9 support in CircleCI. At least this way we can verify that everything else works in Java 9.