### PR TITLE
Add continuous deployment to App Engine for new pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,32 @@ jobs:
     docker:
       - image: circleci/openjdk:9-jdk
 
+  deploy:
+    << : *build
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - deploy-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - deploy-dependencies-
+
+      - run: sed -Ei "s:<version>.*</version>:<version>$(git rev-parse --abbrev-ref HEAD)</version>:" src/main/webapp/WEB-INF/appengine-web.xml
+      - run: cat src/main/webapp/WEB-INF/appengine-web.xml
+      - run: echo "${APPCFG_OAUTH_TOKENS}" > ~/.appcfg_oauth2_tokens_java
+      - run: mvn appengine:update
+      - run: mvn dependency:go-offline
+      - run: 'curl "https://api.github.com/repos/codeu-2018-team12/codeu-2018-team12/statuses/$(git rev-parse HEAD)?access_token=${GITHUB_ACCESS_TOKEN}" -X POST --data ''{"state": "success", "target_url": "https://''"$(git rev-parse --abbrev-ref HEAD)"''-dot-chatu-196017.appspot.com", "description": "Click Details to see a test instance:", "context": "App Engine Demo"}'' '
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: deploy-dependencies-{{ checksum "pom.xml" }}
+
 workflows:
   version: 2
-  build_both_versions:
+  build_and_deploy:
     jobs:
       - build-java8
       - build-java9
+      - deploy


### PR DESCRIPTION
It would be nice to be able to see a test instance when deploying code.

This CL adds a custom Github deployment action to CircleCI, which shows up under the "Checks Have Passed" menu. (Note that because of #71, the test instance won't work. Also, there's a good chance of weird cache coherence issues, since the persistence layer stores everything in memory.)