### PR TITLE
Addressing bugs

### DIFF
--- a/src/main/java/codeu/controller/BounceHandlerServlet.java
+++ b/src/main/java/codeu/controller/BounceHandlerServlet.java
@@ -25,6 +25,8 @@ public class BounceHandlerServlet extends HttpServlet {
                 + " to "
                 + bounce.getOriginal().getTo()
                 + " has been bounced.");
+        log. warning("Subject:" + bounce.getOriginal().getSubject() +
+                " \n Text" + bounce.getOriginal().getText());
       }
     } catch (MessagingException e) {
       System.out.println("A messaging exception has occurred.");

--- a/src/main/java/codeu/controller/BounceHandlerServlet.java
+++ b/src/main/java/codeu/controller/BounceHandlerServlet.java
@@ -2,7 +2,6 @@ package codeu.controller;
 
 import com.google.appengine.api.mail.BounceNotification;
 import com.google.appengine.api.mail.BounceNotificationParser;
-
 import java.io.IOException;
 import java.util.logging.Logger;
 import javax.mail.MessagingException;
@@ -25,8 +24,11 @@ public class BounceHandlerServlet extends HttpServlet {
                 + " to "
                 + bounce.getOriginal().getTo()
                 + " has been bounced.");
-        log. warning("Subject:" + bounce.getOriginal().getSubject() +
-                " \n Text" + bounce.getOriginal().getText());
+        log.warning(
+            "Subject:"
+                + bounce.getOriginal().getSubject()
+                + " \n Text"
+                + bounce.getOriginal().getText());
       }
     } catch (MessagingException e) {
       System.out.println("A messaging exception has occurred.");

--- a/src/main/java/codeu/controller/BounceHandlerServlet.java
+++ b/src/main/java/codeu/controller/BounceHandlerServlet.java
@@ -1,0 +1,33 @@
+package codeu.controller;
+
+import com.google.appengine.api.mail.BounceNotification;
+import com.google.appengine.api.mail.BounceNotificationParser;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+import javax.mail.MessagingException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class BounceHandlerServlet extends HttpServlet {
+
+  private static final Logger log = Logger.getLogger(BounceHandlerServlet.class.getName());
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    try {
+      BounceNotification bounce = BounceNotificationParser.parse(req);
+      if (bounce.getOriginal() != null) {
+        log.warning(
+            "The email from "
+                + bounce.getOriginal().getFrom()
+                + " to "
+                + bounce.getOriginal().getTo()
+                + " has been bounced.");
+      }
+    } catch (MessagingException e) {
+      System.out.println("A messaging exception has occurred.");
+    }
+  }
+}

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -146,7 +146,12 @@ public class ConversationServlet extends HttpServlet {
     if (conversationStore.isTitleTaken(conversationTitle)) {
       // conversation title is already taken, just go into that conversation instead of creating a
       // new one
-      response.sendRedirect("/chat/" + conversationTitle);
+      User loggedInUser = userStore.getUser(username);
+      List<Conversation> conversations =
+              conversationStore.getAllPermittedConversationsSorted(loggedInUser.getId());
+      request.setAttribute("conversations", conversations);
+      request.setAttribute("error", "This conversation name is already taken.");
+      request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
       return;
     }
 

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -148,7 +148,7 @@ public class ConversationServlet extends HttpServlet {
       // new one
       User loggedInUser = userStore.getUser(username);
       List<Conversation> conversations =
-              conversationStore.getAllPermittedConversationsSorted(loggedInUser.getId());
+          conversationStore.getAllPermittedConversationsSorted(loggedInUser.getId());
       request.setAttribute("conversations", conversations);
       request.setAttribute("error", "This conversation name is already taken.");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -70,9 +70,9 @@ public class PersistentDataStore {
         String biography = (String) entity.getProperty("biography");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
         String email =
-                entity.getProperty("email") == null
-                        ? "codeUChatTest@gmail.com"
-                        : (String) entity.getProperty("email");
+            entity.getProperty("email") == null
+                ? "codeUChatTest@gmail.com"
+                : (String) entity.getProperty("email");
         if (password != null && !password.startsWith("$2a$")) {
           password = BCrypt.hashpw(password, BCrypt.gensalt());
         }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -69,7 +69,10 @@ public class PersistentDataStore {
         String password = (String) entity.getProperty("password");
         String biography = (String) entity.getProperty("biography");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
-        String email = (String) entity.getProperty("email");
+        String email =
+                entity.getProperty("email") == null
+                        ? "codeUChatTest@gmail.com"
+                        : (String) entity.getProperty("email");
         if (password != null && !password.startsWith("$2a$")) {
           password = BCrypt.hashpw(password, BCrypt.gensalt());
         }

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -21,3 +21,10 @@
     <sessions-enabled>true</sessions-enabled>
     <runtime>java8</runtime>
 </appengine-web-app>
+
+<inbound-services>
+<!-- Used to handle incoming mail. -->
+<service>mail</service>
+<!-- Used to handle bounced mail notifications. -->
+<service>mail_bounce</service>
+</inbound-services>

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -20,11 +20,11 @@
     <threadsafe>false</threadsafe>
     <sessions-enabled>true</sessions-enabled>
     <runtime>java8</runtime>
-</appengine-web-app>
 
-<inbound-services>
-<!-- Used to handle incoming mail. -->
-<service>mail</service>
-<!-- Used to handle bounced mail notifications. -->
-<service>mail_bounce</service>
-</inbound-services>
+    <inbound-services>
+        <!-- Used to handle incoming mail. -->
+        <service>mail</service>
+        <!-- Used to handle bounced mail notifications. -->
+        <service>mail_bounce</service>
+    </inbound-services>
+</appengine-web-app>

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -75,7 +75,7 @@
     }
     %>
     <hr/>
-    <% if(!directMessages.isEmpty()){
+    <% if(directMessages != null && !directMessages.isEmpty()){
     %>
       <h1>Direct Messages</h1>
       <ul class="mdl-list">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -142,7 +142,7 @@
 
   <servlet>
     <servlet-name>bouncehandler</servlet-name>
-    <servlet-class>com.example.appengine.mail.BounceHandlerServlet</servlet-class>
+    <servlet-class>codeu.controller.BounceHandlerServlet</servlet-class>
   </servlet>
 
   <servlet-mapping>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -140,4 +140,24 @@
     <url-pattern>/personalActivityFeed</url-pattern>
   </servlet-mapping>
 
+  <servlet>
+    <servlet-name>bouncehandler</servlet-name>
+    <servlet-class>com.example.appengine.mail.BounceHandlerServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>bouncehandler</servlet-name>
+    <url-pattern>/_ah/bounce</url-pattern>
+  </servlet-mapping>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>bounce</web-resource-name>
+      <url-pattern>/_ah/bounce</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>admin</role-name>
+    </auth-constraint>
+  </security-constraint>
+
 </web-app>

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -176,8 +176,9 @@ public class ConversationServletTest {
     conversationServlet.doPost(mockRequest, mockResponse);
 
     Mockito.verify(mockConversationStore, Mockito.never())
-        .addConversation(Mockito.any(Conversation.class));
-    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+            .addConversation(Mockito.any(Conversation.class));
+    Mockito.verify(mockRequest).setAttribute("error", "This conversation name is already taken.");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 
   @Test

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -176,7 +176,7 @@ public class ConversationServletTest {
     conversationServlet.doPost(mockRequest, mockResponse);
 
     Mockito.verify(mockConversationStore, Mockito.never())
-            .addConversation(Mockito.any(Conversation.class));
+        .addConversation(Mockito.any(Conversation.class));
     Mockito.verify(mockRequest).setAttribute("error", "This conversation name is already taken.");
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }


### PR DESCRIPTION
This adds:
1. Bounce notifications for emails that are not properly sent (Jeremy, I still have to investigate why the email notification was not properly sent when you tried it). 
2. Gives users without an email a default email of codeUChatTest@gmail.com (I thought this would be better for testing purposes and to temporarily prevent the null pointer issue since emails are required now and all new users will have one). I think in the long run for users without emails we can disable notifications as the default notifications setting and on the settings page if a user does not have an email set up we can prompt them for one. I can add this to the next PR
3. Prevents the creation of conversations with the same name + fixes a null pointer issue with empty conversation names