### PR TITLE
PersonalizedActivityFeed and Privacy Logic Fixes

### DIFF
--- a/src/main/java/codeu/controller/PersonalActivityServlet.java
+++ b/src/main/java/codeu/controller/PersonalActivityServlet.java
@@ -82,32 +82,32 @@ public class PersonalActivityServlet extends HttpServlet {
     UUID userID = user.getId();
     List<Conversation> conversations = sort(conversationStore.getAllConversations());
     List<Activity> conversationActivities = new ArrayList<>();
-    List<Activity> tailoredActivities = new ArrayList<>();
 
     // retrieve activities for the conversations a user has joined
     for (Conversation conversation : conversations) {
-      List<UUID> conversationUsers = conversation.getConversationUsers();
-      if (conversationUsers.contains(user.getId())) {
-        conversationActivities.add(
-            activityStore.getActivityWithConversationID(conversation.getId()));
+      if (conversation.getConversationUsers() != null) {
+        List<UUID> conversationUsers = conversation.getConversationUsers();
+        if (conversationUsers.contains(user.getId())) {
+          conversationActivities.add(
+              activityStore.getActivityWithConversationID(conversation.getId()));
+        }
       }
     }
-    tailoredActivities.addAll(conversationActivities);
+    List<Activity> tailoredActivities = new ArrayList<>(conversationActivities);
 
     // retrieve user activities
     List<Activity> userActivities = activityStore.getActivitiesWithUserID(userID);
-    tailoredActivities.addAll(userActivities);
+    if (userActivities != null) {
+      tailoredActivities.addAll(userActivities);
+    }
 
     // remove any duplicates
-    Set<Activity> hashSet = new HashSet<>();
-    hashSet.addAll(tailoredActivities);
+    Set<Activity> hashSet = new HashSet<>(tailoredActivities);
     tailoredActivities.clear();
     tailoredActivities.addAll(hashSet);
 
-    // sort the activities
-    List<Activity> personalizedActivities = sort(tailoredActivities);
     List<Activity> privacyActivities =
-        sort(activityStore.getActivitiesPerPrivacy(user, personalizedActivities));
+        sort(activityStore.getActivitiesPerPrivacy(user, tailoredActivities));
 
     request.setAttribute("activities", privacyActivities);
     request

--- a/src/main/java/codeu/model/store/basic/ActivityStore.java
+++ b/src/main/java/codeu/model/store/basic/ActivityStore.java
@@ -128,21 +128,29 @@ public class ActivityStore {
   public List<Activity> getActivitiesPerPrivacy(User currentUser, List<Activity> activities1) {
     UserStore userstore = UserStore.getInstance();
     List<Activity> activitiesPerPrivacy = new ArrayList<>();
-    for (Activity activity : activities1) {
-      UUID activityUserID = activity.getUserId();
-      User user = userstore.getUser(activityUserID);
-      if (currentUser != null
-          && user != null
-          && currentUser.getConversationFriends().contains(activityUserID)
-          && (user.getActivityFeedPrivacy().equals("someContent"))) {
-        activitiesPerPrivacy.add(activity);
-      } else if (user != null && user.getActivityFeedPrivacy().equals("allContent")) {
-        activitiesPerPrivacy.add(activity);
-      } else if (currentUser != null && activityUserID.equals(currentUser.getId())) {
-        activitiesPerPrivacy.add(activity);
+    if (activities1 == null) {
+      return activitiesPerPrivacy;
+    } else {
+      for (Activity activity : activities1) {
+        if (activity != null) {
+          UUID activityUserID = activity.getUserId();
+          User user = userstore.getUser(activityUserID);
+          if (user != null && user.equals(currentUser)) {
+            activitiesPerPrivacy.add(activity);
+          } else if (currentUser != null
+              && user != null
+              && currentUser.getConversationFriends().contains(activityUserID)
+              && (user.getActivityFeedPrivacy().equals("someContent"))) {
+            activitiesPerPrivacy.add(activity);
+          } else if (user != null && user.getActivityFeedPrivacy().equals("allContent")) {
+            activitiesPerPrivacy.add(activity);
+          } else if (currentUser != null && activityUserID.equals(currentUser.getId())) {
+            activitiesPerPrivacy.add(activity);
+          }
+        }
       }
+      return activitiesPerPrivacy;
     }
-    return activitiesPerPrivacy;
   }
 
   /** Add a new activity to the current set of activities known to the application. */

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -94,7 +94,8 @@ User loggedInUser = (User) request.getAttribute("loggedInUser");
          <h2>Recent Activity</h2>
          <div id="activities">
           <ul>
-           <% if ((!(user.getProfilePrivacy().equals("noContent"))) || ((user.getProfilePrivacy().equals("someContent"))
+           <% if (((user.getProfilePrivacy().equals("noContent")) && (loggedInUser.equals(user)))
+              || ((user.getProfilePrivacy().equals("allContent"))) || ((user.getProfilePrivacy().equals("someContent"))
               && (loggedInUser.getConversationFriends().contains(user.getId())))) { %>
            <%
              for (Activity activity : activities) {


### PR DESCRIPTION
Updated getActivitiesPerPrivacy logic to include adding all activities if you are the current user no matter your own privacy settings, fixed NPE for personalized activity feed, and fixed profile.jsp to incorporate appropriate logic for users who have noContent as their privacy settings